### PR TITLE
Support status queries via GET request

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from http.client import HTTPException
 
 from flask import Flask, jsonify, request
 from blinkt import set_brightness, set_pixel, show, clear, get_pixel, NUM_PIXELS
+import json
 
 app = Flask(__name__)
 
@@ -160,6 +161,19 @@ def turn_custom():
         "message": "Custom pattern applied"
     }
 
+    return jsonify(data)
+
+@app.route('/status', methods=['GET'])
+def report_status():
+    pixel_status = []
+    for i in range(NUM_PIXELS):
+        pixel_status.append(dict(Pixel=i, Status=dict(zip(["Red","Green","Blue","Brightness"],get_pixel(i)))))
+    pixel_status = json.dumps(pixel_status)
+    data = {
+        "status": 200,
+        "message": pixel_status
+    }
+    
     return jsonify(data)
 
 

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import time
 from http.client import HTTPException
 
 from flask import Flask, jsonify, request
-from blinkt import set_brightness, set_pixel, show, clear
+from blinkt import set_brightness, set_pixel, show, clear, get_pixel, NUM_PIXELS
 
 app = Flask(__name__)
 
@@ -74,7 +74,7 @@ def handle_error(e):
 def set_red():
     set_brightness(0.5)
 
-    for x in range(8):
+    for x in range(NUM_PIXELS):
         set_pixel(x, 255, 0, 0)
         show()
 
@@ -89,7 +89,7 @@ def set_red():
 def set_green():
     set_brightness(0.5)
 
-    for x in range(8):
+    for x in range(NUM_PIXELS):
         set_pixel(x, 0, 255, 0)
         show()
 
@@ -104,7 +104,7 @@ def set_green():
 def set_blue():
     set_brightness(0.5)
 
-    for x in range(8):
+    for x in range(NUM_PIXELS):
         set_pixel(x, 0, 0, 255)
         show()
 
@@ -119,7 +119,7 @@ def set_blue():
 def turn_off():
     set_brightness(0)
 
-    for x in range(8):
+    for x in range(NUM_PIXELS):
         set_pixel(x, 0, 0, 0)
         show()
 

--- a/app.py
+++ b/app.py
@@ -168,13 +168,12 @@ def report_status():
     pixel_status = []
     for i in range(NUM_PIXELS):
         pixel_status.append(dict(Pixel=i, Status=dict(zip(["Red","Green","Blue","Brightness"],get_pixel(i)))))
-    pixel_status = json.dumps(pixel_status)
     data = {
         "status": 200,
         "message": pixel_status
     }
-    
-    return jsonify(data)
+
+    return jsonify(data) # This ruins the order of keys for humans. JSON doesn't care, and neither do we.
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As you may have noticed, `jsonify` creates alphabetically ordered lists from our data, regardless of how we provide it. As mentioned in the [flask documentation](https://flask.palletsprojects.com/en/0.12.x/config/#builtin-configuration-values), we can achieve ordered output at the potential cost of cacheability.